### PR TITLE
Router.rewriteTo

### DIFF
--- a/lib/__tests__/router.spec.js
+++ b/lib/__tests__/router.spec.js
@@ -58,6 +58,7 @@ describe('Router', function () {
     expect(Router.start).to.be.a('function');
     expect(Router.getURLFromRoute).to.be.a('function');
     expect(Router.linkTo).to.be.a('function');
+    expect(Router.rewriteTo).to.be.a('function');
     expect(Router.beforeEach).to.be.a('function');
     expect(Router.afterEach).to.be.a('function');
     expect(Router.clearEach).to.be.a('function');
@@ -108,6 +109,18 @@ describe('Router', function () {
 
     expect(IndexRoute.called).to.be(false);
     expect(MailboxRoute.calledWithExactly('5')).to.be(true);
+  });
+
+  it('should rewriteTo mailbox', function () {
+    Router.rewriteTo('mailbox', [5]);
+
+    expect(ResetRoute.called).to.be(false);
+    expect(IndexRoute.called).to.be(false);
+    expect(MailboxRoute.called).to.be(false);
+    expect(RouteStore.getRouteName()).to.be('mailbox');
+    expect(RouteStore.getRouteParams()[0]).to.be(5); // todo: consistent with linkTo?
+    expect(RouteStore.getRouteParams().length).to.be(1);
+    expect(RouteStore.getURL()).to.be('#box/5');
   });
 
   it('should call beforeEach', function () {

--- a/lib/router.js
+++ b/lib/router.js
@@ -23,6 +23,7 @@ var _router,
   getURLFromRoute,
   isMatch,
   linkTo,
+  rewriteTo,
   beforeEach,
   afterEach,
   clearEach;
@@ -141,6 +142,18 @@ linkTo = function (name, params) {
 };
 
 /**
+ * Rewrites route, url, and params based on a route by name, passing in the array of parameters.
+ * Similar to linkTo -- except that browser location and history are unaffected
+ *
+ * @param string name The name of the route to rewrite to.
+ * @param array params The list of parameters include in the rewritten URL
+ */
+rewriteTo = function (name, params) {
+  var url = getURLFromRoute(name, params);
+  RouteActionCreators.changeRoute(url, name, params);
+};
+
+/**
  * Register a callback to be invoked before each route.
  * This callback will be passed: name {string}, params {array}
  * @param func callback
@@ -148,7 +161,6 @@ linkTo = function (name, params) {
 beforeEach = function (callback) {
   _beforeCallbacks.push(callback);
 };
-
 
 /**
  * Register a callback to be invoked after each route.
@@ -170,8 +182,7 @@ clearEach = function () {
 
 // Trigger changeRoute after each route
 afterEach(function (name, params) {
-  var url = getURLFromRoute(name, params);
-  RouteActionCreators.changeRoute(url, name, params);
+  rewriteTo(name, params);
 });
 
 export default {
@@ -179,6 +190,7 @@ export default {
   getURLFromRoute: getURLFromRoute,
   isMatch: isMatch,
   linkTo: linkTo,
+  rewriteTo: rewriteTo,
   beforeEach: beforeEach,
   afterEach: afterEach,
   clearEach: clearEach


### PR DESCRIPTION
- this feature allows the app to update the activeURL, route, and params
  without updating the location in the browser nor adding a history entry
- this is useful for cases where say the index route "/" should act
  like "mailbox", [5] which is "/mailbox/5" without adding a history entry
  nor updating the location
